### PR TITLE
Move charmed-kafka from DockerHub to GitHub Container Registry

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,12 +30,18 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup LXD
         uses: canonical/setup-lxd@main
-      - name: Install rockcraft
+      - name: Install dependencies
         run: |
-          sudo snap install --classic --channel edge rockcraft
+          sudo snap install yq
+          sudo snap install rockcraft --classic --edge
       - name: Build ROCK
-        run: rockcraft pack --verbose
-
+        run: |
+          app_version=$(yq '.version' rockcraft.yaml)
+          version=$(yq '(.version|split("-"))[0]' rockcraft.yaml)
+          base=$(yq '(.base|split(":"))[1]' rockcraft.yaml)
+          tag=${version}-${base}_edge
+          sed -i "s/${app_version}/${tag}/g" rockcraft.yaml
+          rockcraft pack --verbose
       - name: Upload locally built ROCK artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -29,19 +31,18 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: charmed-kafka
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
-      - name: Import and push to Docker Hub
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Import and push to GHCR
         run: |
-          version="$(cat rockcraft.yaml | yq e '.version')"
-          sudo skopeo \
-            --insecure-policy \
-            copy \
-            oci-archive:"charmed-kafka_${version}_amd64.rock" \
-            docker-daemon:"charmed/kafka:${version}"
-          docker push "charmed/kafka:${version}"
+          version=$(yq '(.version|split("-"))[0]' rockcraft.yaml)
+          base=$(yq '(.base|split(":"))[1]' rockcraft.yaml)
+          tag=${version}-${base}_edge
+          sudo skopeo --insecure-policy copy \
+            oci-archive:charmed-kafka_${tag}_amd64.rock \
+            docker-daemon:ghcr.io/canonical/charmed-kafka:${tag}
+          docker push ghcr.io/canonical/charmed-kafka:${tag}


### PR DESCRIPTION
Closes: [DPE-1561](https://warthogs.atlassian.net/browse/DPE-1561)

# Issue:
Docker is sun-setting Free Team organizations, including https://hub.docker.com/r/charmed

# Solution
Moving to GitHub Container Registry (ghcr.io). OCI Tags are described [here](https://warthogs.atlassian.net/browse/DPE-1502?focusedCommentId=209163).

[DPE-1561]: https://warthogs.atlassian.net/browse/DPE-1561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ