### PR TITLE
refactor: use opt/kafka/bin

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -17,8 +17,19 @@ license: Apache-2.0  # your application's SPDX license
 platforms:  # The platforms this ROCK should be built on and run on
   amd64:
 
-env:
-  - JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
+services:
+  kafka:
+    override: replace
+    command: /opt/kafka/bin/kafka-server-start.sh /etc/kafka/server.properties
+    startup: enabled
+    user: kafka
+    group: kafka
+    environment:
+      JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
+      KAFKA_OPTS: "-javaagent:/opt/kafka/jmx_prometheus_javaagent.jar=\n
+        9101:/etc/kafka/jmx_prometheus.yaml\n
+        -Djava.security.auth.login.config=\n
+        /etc/kafka/kafka-jaas.cfg"
 
 parts:
   kafka:
@@ -37,14 +48,23 @@ parts:
       ln -s /usr/lib/jvm/java-17-openjdk-amd64/bin/keytool \
         $CRAFT_PART_INSTALL/usr/bin/keytool
 
+      # making core dirs
       mkdir -p $CRAFT_PART_INSTALL/var/lib/pebble/default/
       mkdir -p $CRAFT_PART_INSTALL/var/lib/kafka/
       mkdir -p $CRAFT_PART_INSTALL/var/log/kafka/
       mkdir -p $CRAFT_PART_INSTALL/opt/kafka/
       mkdir -p $CRAFT_PART_INSTALL/etc/kafka/
+
+      # creating kafka root_dir
+      mkdir -p $CRAFT_PART_INSTALL/opt/kafka/libs
+      mkdir -p $CRAFT_PART_INSTALL/opt/kafka/bin
     override-prime: |
       craftctl default
       rm -vf usr/lib/jvm/java-17-openjdk-amd64/lib/security/cacerts
+    organize:
+      bin: opt/kafka/bin/
+      libs: opt/kafka/libs/
+      config: opt/kafka/config/
   non-root-user:
     plugin: nil
     after: [kafka]
@@ -56,7 +76,7 @@ parts:
       craftctl default
       # Give permission ot the required folders
       install -d -o 1000 -g 1000 -m 770 \
-      opt/kafka \
-      var/lib/kafka \
-      var/log/kafka \
-      etc/kafka
+        opt/kafka \
+        var/lib/kafka \
+        var/log/kafka \
+        etc/kafka

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -54,10 +54,6 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/var/log/kafka/
       mkdir -p $CRAFT_PART_INSTALL/opt/kafka/
       mkdir -p $CRAFT_PART_INSTALL/etc/kafka/
-
-      # creating kafka root_dir
-      mkdir -p $CRAFT_PART_INSTALL/opt/kafka/libs
-      mkdir -p $CRAFT_PART_INSTALL/opt/kafka/bin
     override-prime: |
       craftctl default
       rm -vf usr/lib/jvm/java-17-openjdk-amd64/lib/security/cacerts


### PR DESCRIPTION
## Changes Made
##### `refactor: add default service`
- Rockcraft now requires Pebble services - [see documentation](https://discourse.canonical.com/t/pebble-as-the-default-oci-entrypoint-for-all-rocks/1756)
##### `chore: create root-dir in opt/kafka/`
- `bin/kafka-*.sh` commands all call `bin/kafka-run-class.sh` as a wrapper
- In that script, Kafka has a `base_dir=$(dirname $0)` check. It uses this to find the root directory, in turn to grab all the JARs it needs 
- Before ROCK changes in https://github.com/canonical/charmed-kafka-rock/pull/8, we unpacked everything to`/opt/kafka`. `base_dir=/opt/kafka` would then be the 'root' under which everything was
- We now unpack to the root directory, so `./bin/kafka-*.sh` would be under the root `/bin/*`. `/bin/*` symlinks to `/usr/bin`. When you run `dirname $0` on `/bin/kafka-*.sh`, you get `/usr`. Nothing is in `/usr` of course
- Now, we've moved everything essential to Kafka functioning (`bin`, `libs` and `configs`) to `/opt/kafka`
    - NOTE - This is different to the VM charm, which has it under `/bin` and `/libs` etc. It might be a good idea to align the two and have them both under `/opt/kafka/` 