### PR TITLE
[DPE-3457] Add description to OCI image to be rendered on GitHub Cont…

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -93,9 +93,10 @@ jobs:
             docker-daemon:${IMAGE_NAME}:${TAG}
 
           COMMIT_ID=$(git log -1 --format=%H)
+          DESCRIPTION=$(yq .description rockcraft.yaml | xargs)
           
           # Add relevant labels
-          echo "FROM ${IMAGE_NAME}:${TAG}" | docker build --label org.opencontainers.image.revision="${COMMIT_ID}" --label org.opencontainers.image.source="${{ github.repositoryUrl }}" -t "${IMAGE_NAME}:${TAG}" -
+          echo "FROM ${IMAGE_NAME}:${TAG}" | docker build --label org.opencontainers.image.description="${DESCRIPTION}" --label org.opencontainers.image.revision="${COMMIT_ID}" --label org.opencontainers.image.source="${{ github.repositoryUrl }}" -t "${IMAGE_NAME}:${TAG}" -
 
           echo "Publishing ${IMAGE_NAME}:${TAG}"          
           docker push ${IMAGE_NAME}:${TAG}


### PR DESCRIPTION
…ainer Registry

This [page](https://github.com/canonical/charmed-kafka-rock/pkgs/container/charmed-kafka/169796414?tag=3-22.04_edge) is not populated. This small fix should solve this. The Description of the yaml is used for this.