### PR TITLE
build: alternative way to stage snap with rev

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -40,9 +40,11 @@ parts:
       - curl
     build-environment:
       - JAVA_HOME: /usr/lib/jvm/java-21-openjdk-amd64
-    stage-snaps:
-      - charmed-kafka/4/edge
+      - SNAP_REVISION: 67
     override-build: |
+      snap download charmed-kafka --revision $SNAP_REVISION
+      unsquashfs charmed-kafka_$SNAP_REVISION.snap
+
       ln -s /usr/lib/jvm/java-21-openjdk-amd64/bin/java \
         $CRAFT_PART_INSTALL/usr/bin/java
       ln -s /usr/lib/jvm/java-21-openjdk-amd64/bin/keytool \
@@ -59,9 +61,7 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/var/log/connect/
       mkdir -p $CRAFT_PART_INSTALL/var/log/cruise-control/
     organize:
-      bin: opt/kafka/bin/
-      libs: opt/kafka/libs/
-      config: opt/kafka/config/
+      /root/parts/kafka/build/squashfs-root: /
   non-root-user:
     plugin: nil
     after: [kafka]


### PR DESCRIPTION
The change proposed [here](https://github.com/canonical/charmed-kafka-rock/pull/34) didn't work because it did not stage snap properly. While that change has been reverted, I've come up with this alternative which has been tested with the charm and works perfectly, and also has the benefit of snap revision pinning, which makes our builds deterministic. 