### PR TITLE
[DPE-10825] chore: update to snap rev. 77

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap install yq
-          sudo snap install rockcraft --classic --edge
+          sudo snap install rockcraft --classic
       - name: Build ROCK
         id: build
         run: |

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -3,7 +3,7 @@
 ---
 name: charmed-kafka  # the name of your ROCK
 base: ubuntu@24.04  # the base environment for this ROCK
-version: '4.2.0'  # just for humans. Semantic versioning is recommended
+version: '4.3.0'  # just for humans. Semantic versioning is recommended
 summary: Charmed Kafka ROCK OCI  # 79 char long summary
 description: |
   This is an OCI image that bundles Apache Kafka together with other tools
@@ -38,12 +38,19 @@ parts:
       - openjdk-21-jre-headless
       - libpsl5
       - curl
+      - python3
     build-environment:
       - JAVA_HOME: /usr/lib/jvm/java-21-openjdk-amd64
-      - SNAP_REVISION: 69
+      - SNAP_REVISION: 77
     override-build: |
       snap download charmed-kafka --revision $SNAP_REVISION
       unsquashfs charmed-kafka_$SNAP_REVISION.snap
+
+      rm -rf squashfs-root/bin  # Python binaries are not required
+      mkdir -p squashfs-root/opt/python-exporter
+      # to avoid lib conflicts
+      mv squashfs-root/lib squashfs-root/opt/python-exporter/lib
+      mv squashfs-root/lib64 squashfs-root/opt/python-exporter/lib64
 
       ln -s /usr/lib/jvm/java-21-openjdk-amd64/bin/java \
         $CRAFT_PART_INSTALL/usr/bin/java
@@ -75,6 +82,7 @@ parts:
       # Give permission ot the required folders
       install -d -o 584792 -g 584792 -m 770 \
         opt/kafka \
+        opt/python-exporter \
         var/lib/kafka \
         etc/kafka \
         etc/connect \


### PR DESCRIPTION
## Description

- Bumps to snap `rev. 77`. i.e. Apache Kafka `4.3.0` with KIP-714 metrics reporter and K8s-compatible Python exporter 
- Fixes a staging issue happening since snap rev. 73 upwards, due to addition of Python libs to the snap (also happens if we use the `stage-snaps` key).
